### PR TITLE
Upgrade dnscontrol to v2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackexchange/dnscontrol:v0.2.8@sha256:007447bf199e74964b854b40585bd3ad1e60c6586fbb5e46c935fe9ffbaeedb3
+FROM stackexchange/dnscontrol:v2.9@sha256:36354bc0e988cdc0fd4c9e69dee3408ca6f98014ea1c7220dff1362c1799a904
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"


### PR DESCRIPTION
Release notes: https://github.com/StackExchange/dnscontrol/releases/tag/v2.9