### PR TITLE
Define an output in the action file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   args:
     description: DNSControl command
     required: true
+outputs:
+  output:
+    description: The output of the dnscontrol command that was executed.
 runs:
   using: docker
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,13 @@
 
 set -eo pipefail
 
-sh -c "dnscontrol $*"
+OUTPUT=`sh -c "dnscontrol $1"`
+
+echo "$OUTPUT"
+
+# https://github.community/t/set-output-truncates-multiline-strings/16852/3
+OUTPUT="${OUTPUT//'%'/'%25'}"
+OUTPUT="${OUTPUT//$'\n'/'%0A'}"
+OUTPUT="${OUTPUT//$'\r'/'%0D'}"
+
+echo "::set-output name=output::$OUTPUT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-OUTPUT=`sh -c "dnscontrol $1"`
+IFS=
+OUTPUT="$(dnscontrol "$1")"
 
 echo "$OUTPUT"
 


### PR DESCRIPTION
We'll set an output in the Actions metadata file ([link](https://help.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs)) so users can do _something_ with that output.

---

My specific usecase was that I want my own GitHub action to comment the diff of `dnscontrol preview` on the PR, instead of having to dig down into the "Checks" tab after every push. I'm open to other names than "output", but I wanted to keep it nice and generic, as "diff" wouldn't be suitable for commands like `dnscontrol push` or `check`.