### PR TITLE
Updated PR comment example syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
 
       - name: DNSControl preview
         uses: koenrh/dnscontrol-action@v3
+        id: dnscontrol_preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         with:
@@ -82,8 +83,9 @@ for the preview job.
 Done. 6 corrections.
 ```
 
-Provided that your GitHub Action job for 'preview' is named `preview`, you could
-use the following snippet to enable pull request comments using Unsplash's [comment-on-pr](https://github.com/unsplash/comment-on-pr)
+Provided that your GitHub Action job for 'preview' has an id
+`dnscontrol_preview`, you could use the following snippet to enable pull request
+comments using Unsplash's [comment-on-pr](https://github.com/unsplash/comment-on-pr)
 GitHub Action.
 
 ```yaml
@@ -94,7 +96,7 @@ GitHub Action.
   with:
     msg: |
       ```
-      ${{ steps.preview.outputs.output }}
+      ${{ steps.dnscontrol_preview.outputs.output }}
       ```
     check_for_duplicate_msg: true
 ```


### PR DESCRIPTION
The comment PR example using steps.preview.outputs.output was not
working despite naming the job 'preview' as defined. While
troubleshooting I found examples that made reference to setting a
specific step id that could then be referenced to get its output. This
worked for me so I updated the documentation to show to use this more
explicit reference.