### PR TITLE
Allow any number of arguments and forward the dnscontrol exit code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -o pipefail
 
 # Resolve to full paths
 CONFIG_ABS_PATH="$(readlink -f "${INPUT_CONFIG_FILE}")"
@@ -10,7 +10,7 @@ WORKING_DIR="$(dirname "${CONFIG_ABS_PATH}")"
 cd "$WORKING_DIR"
 
 ARGS=(
-  "$1"
+  "$@"
    --config "$CONFIG_ABS_PATH"
 )
 
@@ -21,6 +21,7 @@ fi
 
 IFS=
 OUTPUT="$(dnscontrol "${ARGS[@]}")"
+EXIT_CODE="$?"
 
 echo "$OUTPUT"
 
@@ -30,3 +31,4 @@ OUTPUT="${OUTPUT//$'\n'/'%0A'}"
 OUTPUT="${OUTPUT//$'\r'/'%0D'}"
 
 echo "::set-output name=output::$OUTPUT"
+exit $EXIT_CODE


### PR DESCRIPTION
I wanted to use the --expect-no-changes option to ensure that my repository is up to date with my dns server.
So I needed to allow any number of arguments (and not only one) and forward the exit code so I can use the failure() or success() function on github action.

I hope you find this useful.