### PR TITLE
Bump DNSControl from v3.5.0 to v3.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackexchange/dnscontrol:v3.5.0@sha256:ffe67365f79ef8a45b0b6208f35450da51e39d5d405c99999d4e831d72bef8af
+FROM stackexchange/dnscontrol:v3.6.0@sha256:c4f19a7a3eb0be0d358426371fdba4a4193d47fdf699091f14aaea95d3c1173c
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"


### PR DESCRIPTION
Changes: https://github.com/StackExchange/dnscontrol/releases/tag/v3.6.0