### PR TITLE
Bump DNSControl to v3.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackexchange/dnscontrol:v3.5.0@sha256:ffe67365f79ef8a45b0b6208f35450da51e39d5d405c99999d4e831d72bef8af
+FROM stackexchange/dnscontrol:v3.7.0@sha256:215ed29de7b650d321c5d9dddf6a4659d8673346feda20d1eba5c3eeadfc8f0d
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"


### PR DESCRIPTION
Changes: https://github.com/StackExchange/dnscontrol/releases/tag/v3.7.0