### PR TITLE
Bump DNSControl to v3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/koenrh/dnscontrol:v3.13.0@sha256:2e0ff54e609f418d285b776f3bbceee35b73eac8637731395e1a001ad7c38898
+FROM golang:1.18.2-alpine@sha256:e6b729ae22a2f7b6afcc237f7b9da3a27151ecbdcd109f7ab63a42e52e750262 AS install
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"
@@ -8,7 +8,18 @@ LABEL "com.github.actions.description"="Deploy your DNS configuration to multipl
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
 
-RUN apk add --no-cache bash
+ENV DNSCONTROL_VERSION="3.16.0"
+
+RUN go install -ldflags="-s -w" github.com/StackExchange/dnscontrol/v3@v${DNSCONTROL_VERSION}
+
+FROM alpine:3.15@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454
+
+RUN apk -U --no-cache upgrade && \
+    apk add --no-cache bash ca-certificates
+
+COPY --from=install /go/bin/dnscontrol /usr/local/bin/dnscontrol
+
+RUN ["dnscontrol", "version"]
 
 COPY README.md entrypoint.sh bin/filter-preview-output.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Instead of a 'DNSControl' Docker base image, use a multi-stage build where DNSControl is installed using `go install` from the original source. Also bump DNSControl to the latest version ([v3.16.0](https://github.com/StackExchange/dnscontrol/releases/tag/v3.16.0)).