### PR TITLE
Bump DNSControl to v3.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ LABEL "com.github.actions.description"="Deploy your DNS configuration to multipl
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
 
-ENV DNSCONTROL_VERSION="3.27.1"
-ENV DNSCONTROL_CHECKSUM="5ef737707a49e73c02ad57eb98953a667def224cdf0b0e04b741d26df2fdcdd6"
+ENV DNSCONTROL_VERSION="3.28.0"
+ENV DNSCONTROL_CHECKSUM="9a4e3607851d7ea3cf3fde42193de4850b453cd3ac2776dbacac5e13ed63a404"
 
 RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat


### PR DESCRIPTION
https://github.com/StackExchange/dnscontrol/releases/tag/v3.28.0