### PR TITLE
Bump DNSControl to v4.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a
+FROM stackexchange/dnscontrol:4.1.0@sha256:c0aa9022c631ad1390fc3aaae0ef7af2d429b66a0626d44f2b9fc90f38ba54e2
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"
@@ -7,18 +7,6 @@ LABEL "com.github.actions.name"="DNSControl"
 LABEL "com.github.actions.description"="Deploy your DNS configuration to multiple providers."
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
-
-ENV DNSCONTROL_VERSION="3.31.4"
-ENV DNSCONTROL_CHECKSUM="054d236531df2674c9286279596f88f02c1cf7b1448dc5f643f1a1dbe705fe8d"
-
-RUN apk -U --no-cache upgrade && \
-    apk add --no-cache bash ca-certificates curl libc6-compat
-
-RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v$DNSCONTROL_VERSION/dnscontrol-Linux" \
-  -o dnscontrol && \
-  echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
-  chmod +x dnscontrol && \
-  mv dnscontrol /usr/local/bin/dnscontrol
 
 RUN ["dnscontrol", "version"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackexchange/dnscontrol:4.1.0@sha256:c0aa9022c631ad1390fc3aaae0ef7af2d429b66a0626d44f2b9fc90f38ba54e2
+FROM stackexchange/dnscontrol:4.3.0@sha256:cb8f69926cc3685e18f3c5aae4d604c3f7efa6af9d5c4249c04faa14e0097206
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"
@@ -8,7 +8,8 @@ LABEL "com.github.actions.description"="Deploy your DNS configuration to multipl
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
 
-RUN ["dnscontrol", "version"]
+RUN dnscontrol version && \
+    apk add --no-cache bash
 
 COPY README.md entrypoint.sh bin/filter-preview-output.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Moves to using the upstream stackexchange/dnscontrol base image and bumps DNSControl version to v4.3.0.

Credit to @koenrh and @adamus1red for the changes relating to the base image.