### PR TITLE
Brings DNSControl up to date along with some new features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ LABEL "com.github.actions.description"="Deploy your DNS configuration to multipl
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
 
-ENV DNSCONTROL_VERSION="3.31.4"
-ENV DNSCONTROL_CHECKSUM="054d236531df2674c9286279596f88f02c1cf7b1448dc5f643f1a1dbe705fe8d"
+ENV DNSCONTROL_VERSION="4.14.3"
+ENV DNSCONTROL_CHECKSUM="8c7e8a181beb17b130a6365bc81ffd024176951b5082d51539412198907e1e48"
 
 RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat
 
-RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v$DNSCONTROL_VERSION/dnscontrol-Linux" \
+RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v$DNSCONTROL_VERSION/dnscontrol_$DNSCONTROL_VERSION_linux_amd64.tar.gz" \
   -o dnscontrol && \
   echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
   chmod +x dnscontrol && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a
+FROM alpine:3.20.3
 
 LABEL repository="https://github.com/koenrh/dnscontrol-action"
 LABEL maintainer="Koen Rouwhorst <info@koenrouwhorst.nl>"
@@ -14,11 +14,11 @@ ENV DNSCONTROL_CHECKSUM="8c7e8a181beb17b130a6365bc81ffd024176951b5082d5153941219
 RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat tar
 
-RUN mkdir ./dnscontrol-folder && \
-  curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
-  -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C ./dnscontrol-folder && \
-  chmod +x ./dnscontrol-folder/dnscontrol && \
-  mv ./dnscontrol-folder/dnscontrol /usr/local/bin/dnscontrol
+RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v${DNSCONTROL_VERSION}/dnscontrol_${DNSCONTROL_VERSION}_linux_amd64.tar.gz" -o dnscontrol.tar.gz && \
+  echo "$DNSCONTROL_CHECKSUM  dnscontrol.tar.gz" | sha256sum -c - && \
+  tar -xzf "dnscontrol.tar.gz" && \
+  chmod +x dnscontrol && \
+  mv dnscontrol /usr/local/bin/dnscontrol
 
 RUN ["dnscontrol", "version"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@ ENV DNSCONTROL_VERSION="4.14.3"
 ENV DNSCONTROL_CHECKSUM="8c7e8a181beb17b130a6365bc81ffd024176951b5082d51539412198907e1e48"
 
 RUN apk -U --no-cache upgrade && \
-    apk add --no-cache bash ca-certificates curl libc6-compat
+    apk add --no-cache bash ca-certificates curl libc6-compat tar
 
 RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
-  -o dnscontrol && \
-  echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
-  chmod +x dnscontrol && \
-  mv dnscontrol /usr/local/bin/dnscontrol
+  -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C dnscontrol-folder \
+  # echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
+  chmod +x dnscontrol-folder/dnscontrol && \
+  mv dnscontrol-folder/dnscontrol /usr/local/bin/dnscontrol
 
 RUN ["dnscontrol", "version"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat tar
 
 RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
-  -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C dnscontrol-folder \
+  -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C dnscontrol-folder && \
   # echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
   chmod +x dnscontrol-folder/dnscontrol && \
   mv dnscontrol-folder/dnscontrol /usr/local/bin/dnscontrol

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DNSCONTROL_CHECKSUM="8c7e8a181beb17b130a6365bc81ffd024176951b5082d5153941219
 RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat
 
-RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v$DNSCONTROL_VERSION/dnscontrol_$DNSCONTROL_VERSION_linux_amd64.tar.gz" \
+RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
   -o dnscontrol && \
   echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
   chmod +x dnscontrol && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV DNSCONTROL_CHECKSUM="8c7e8a181beb17b130a6365bc81ffd024176951b5082d5153941219
 RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat tar
 
-RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
+RUN mkdir ./dnscontrol-folder && \
+  curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
   -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C ./dnscontrol-folder && \
   chmod +x ./dnscontrol-folder/dnscontrol && \
   mv ./dnscontrol-folder/dnscontrol /usr/local/bin/dnscontrol

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN apk -U --no-cache upgrade && \
     apk add --no-cache bash ca-certificates curl libc6-compat tar
 
 RUN curl -sL "https://github.com/StackExchange/dnscontrol/releases/download/v4.14.3/dnscontrol_4.14.3_linux_amd64.tar.gz" \
-  -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C dnscontrol-folder && \
-  # echo "$DNSCONTROL_CHECKSUM  dnscontrol" | sha256sum -c - && \
-  chmod +x dnscontrol-folder/dnscontrol && \
-  mv dnscontrol-folder/dnscontrol /usr/local/bin/dnscontrol
+  -o dnscontrol.tar.gz && tar -xzvf dnscontrol.tar.gz -C ./dnscontrol-folder && \
+  chmod +x ./dnscontrol-folder/dnscontrol && \
+  mv ./dnscontrol-folder/dnscontrol /usr/local/bin/dnscontrol
 
 RUN ["dnscontrol", "version"]
 

--- a/bin/filter-preview-output.sh
+++ b/bin/filter-preview-output.sh
@@ -6,9 +6,6 @@ grep -v -e '^\.\.\.0 corrections$' |\
   grep -v -e '\.\.\. (skipping)' |\
   grep -v -e '^----- DNS Provider: ' |\
   grep -v -e '^----- Registrar: ' |\
-  grep -v -e -i '^Concurrently ' |\
-  grep -v -e -i '^Serially ' |\
-  grep -v -e '^Waiting for concurrent ' |\
   grep -v -e '^----- Getting nameservers from:' | \
   sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g" # remove ANSI color codes
   ## https://stackoverflow.com/questions/17998978/removing-colors-from-output

--- a/bin/filter-preview-output.sh
+++ b/bin/filter-preview-output.sh
@@ -6,6 +6,9 @@ grep -v -e '^\.\.\.0 corrections$' |\
   grep -v -e '\.\.\. (skipping)' |\
   grep -v -e '^----- DNS Provider: ' |\
   grep -v -e '^----- Registrar: ' |\
+  grep -v -e -i '^Concurrently ' |\
+  grep -v -e -i '^Serially ' |\
+  grep -v -e '^Waiting for concurrent ' |\
   grep -v -e '^----- Getting nameservers from:' | \
   sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g" # remove ANSI color codes
   ## https://stackoverflow.com/questions/17998978/removing-colors-from-output

--- a/bin/filter-preview-output.sh
+++ b/bin/filter-preview-output.sh
@@ -6,4 +6,5 @@ grep -v -e '^\.\.\.0 corrections$' |\
   grep -v -e '\.\.\. (skipping)' |\
   grep -v -e '^----- DNS Provider: ' |\
   grep -v -e '^----- Registrar: ' |\
-  grep -v -e '^----- Getting nameservers from:'
+  grep -v -e '^----- Getting nameservers from:' | \
+  sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g"

--- a/bin/filter-preview-output.sh
+++ b/bin/filter-preview-output.sh
@@ -7,4 +7,5 @@ grep -v -e '^\.\.\.0 corrections$' |\
   grep -v -e '^----- DNS Provider: ' |\
   grep -v -e '^----- Registrar: ' |\
   grep -v -e '^----- Getting nameservers from:' | \
-  sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g"
+  sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g" # remove ANSI color codes
+  ## https://stackoverflow.com/questions/17998978/removing-colors-from-output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,6 @@ WORKING_DIR="$(dirname "${CONFIG_ABS_PATH}")"
 cd "$WORKING_DIR" || exit
 
 ARGS=(
-  #  --no-colors=true
   "$@"
    --config "$CONFIG_ABS_PATH"
 )
@@ -18,6 +17,7 @@ ARGS=(
 # 'check' sub-command doesn't require credentials
 if [ "$1" != "check" ]; then
     ARGS+=(--creds "$CREDS_ABS_PATH")
+    args+=(--cmode concurrent)
 fi
 
 IFS=

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ WORKING_DIR="$(dirname "${CONFIG_ABS_PATH}")"
 cd "$WORKING_DIR" || exit
 
 ARGS=(
-   --no-colors=true
+  #  --no-colors=true
   "$@"
    --config "$CONFIG_ABS_PATH"
 )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ cd "$WORKING_DIR" || exit
 ARGS=(
   "$@"
    --config "$CONFIG_ABS_PATH"
+   --no-colors=true
 )
 
 # 'check' sub-command doesn't require credentials

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ ARGS=(
 # 'check' sub-command doesn't require credentials
 if [ "$1" != "check" ]; then
     ARGS+=(--creds "$CREDS_ABS_PATH")
-    args+=(--cmode concurrent)
+    ARGS+=(--cmode concurrent)
 fi
 
 IFS=

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,9 +10,9 @@ WORKING_DIR="$(dirname "${CONFIG_ABS_PATH}")"
 cd "$WORKING_DIR" || exit
 
 ARGS=(
+   --no-colors=true
   "$@"
    --config "$CONFIG_ABS_PATH"
-   --no-colors=true
 )
 
 # 'check' sub-command doesn't require credentials


### PR DESCRIPTION
Few things here: 

- Updates DNSControl to the latest version (as 3.31.4 came out quite a while ago) 
- Improves the output of the preview to remove color codes, resulting in there not being color codes in the preview comment (without disabling color for the action logs)
- switches it to use concurrent as that's about to be the default.

Personal bugbear that isn't a huge deal: 

With concurrent mode on, the preview looks like this: 


```
CONCURRENTLY gathering 1 zone(s)
SERIALLY gathering 2 zone(s)
Serially Gathering: "example.org"
Serially Gathering: "example.net"
Waiting for concurrent gathering(s) to complete...DONE
******************** Domain: example.com
******************** Domain: example.net
******************** Domain: example.org
2 corrections (porkbun)
#1: + CREATE example.org A 1.1.1.1 ttl=600
#2: + CREATE demo.example.org A 1.1.1.1 ttl=600
Done. 2 corrections.
```

With concurrent off, it looks like this: 

```
******************** Domain: example.com
******************** Domain: example.net
******************** Domain: example.org
2 corrections (porkbun)
#1: + CREATE example.org A 1.1.1.1 ttl=600
#2: + CREATE demo.example.org A 1.1.1.1 ttl=600
Done. 2 corrections.
```

I couldn't quite figure out how to get grep to drop those first few lines, but feel free to amend the PR if you can get it sorted. 